### PR TITLE
solve issue of low contrast

### DIFF
--- a/src/main/res/layout/fragment_main.xml
+++ b/src/main/res/layout/fragment_main.xml
@@ -20,7 +20,7 @@
                 android:gravity="center"
                 android:textSize="16sp"
                 android:layout_margin="@dimen/margin_little"
-                android:textColor="@color/text_on_green"/>
+                android:textColor="#000000"/>
 
         <View
                 android:layout_width="fill_parent"
@@ -43,7 +43,7 @@
                         android:id="@+id/points_team1"
                         android:layout_gravity="center_vertical|left"
                         android:textSize="22sp"
-                        android:textColor="@color/text_on_green"
+                        android:textColor="#000000"
                         android:layout_margin="@dimen/margin"
                         android:gravity="center"/>
 
@@ -55,7 +55,7 @@
                         android:textSize="22sp"
                         android:gravity="center|right"
                         android:layout_margin="@dimen/margin"
-                        android:textColor="@color/text_on_green"
+                        android:textColor="#000000"
                         android:layout_weight="1"/>
             </LinearLayout>
 
@@ -78,7 +78,7 @@
                         android:textSize="22sp"
                         android:gravity="center|left"
                         android:layout_margin="@dimen/margin"
-                        android:textColor="@color/text_on_green"
+                        android:textColor="#000000"
                         android:layout_weight="1"/>
 
                 <TextView
@@ -88,7 +88,7 @@
                         android:layout_gravity="center_vertical|right"
                         android:gravity="center|right"
                         android:textSize="22sp"
-                        android:textColor="@color/text_on_green"
+                        android:textColor="#000000"
                         android:layout_margin="@dimen/margin"/>
             </LinearLayout>
 


### PR DESCRIPTION
The original text color of the component is '#ECECEC', and the contrast between the text color ('#ECECEC') and the background color ('#23910D') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#000000') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167415500-33f6bde4-ee0a-4549-b043-58442ff55750.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.